### PR TITLE
Fix code scanning alert no. 6: Bad HTML filtering regexp

### DIFF
--- a/hacktivespace-frontend/package.json
+++ b/hacktivespace-frontend/package.json
@@ -18,7 +18,8 @@
     "react-router-dom": "^7.1.1",
     "react-slick": "^0.30.3",
     "slick-carousel": "^1.8.1",
-    "tw-elements-react": "^1.0.0-alpha-end"
+    "tw-elements-react": "^1.0.0-alpha-end",
+    "dompurify": "^3.2.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/hacktivespace-frontend/public/plugins/jquery/src/manipulation.js
+++ b/hacktivespace-frontend/public/plugins/jquery/src/manipulation.js
@@ -21,11 +21,12 @@ define( [
 	"./core/init",
 	"./traversing",
 	"./selector",
-	"./event"
+	"./event",
+	"dompurify"
 ], function( jQuery, concat, push, access,
 	rcheckableType, rtagName, rscriptType,
 	wrapMap, getAll, setGlobalEval, buildFragment, support,
-	dataPriv, dataUser, acceptData, DOMEval, nodeName ) {
+	dataPriv, dataUser, acceptData, DOMEval, nodeName, DOMPurify ) {
 
 "use strict";
 
@@ -46,7 +47,7 @@ var
 	// checked="checked" or checked
 	rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
 	rscriptTypeMasked = /^true\/(.*)/,
-	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;
+	rcleanScript = DOMPurify.sanitize;
 
 // Prefer a tbody over its parent table for containing new rows
 function manipulationTarget( elem, content ) {


### PR DESCRIPTION
Fixes [https://github.com/Priyanshukumaranand/Hacktivespace/security/code-scanning/6](https://github.com/Priyanshukumaranand/Hacktivespace/security/code-scanning/6)

To fix the problem, we should replace the custom regular expression with a well-tested library that can handle HTML parsing and sanitization correctly. One such library is `DOMPurify`, which is designed to sanitize HTML and prevent XSS attacks.

1. Install the `DOMPurify` library.
2. Replace the custom regular expression with a call to `DOMPurify` to sanitize the HTML content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
