### PR TITLE
Fix code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/hacktivespace-frontend/public/plugins/slick-carousel/slick/slick.js
+++ b/hacktivespace-frontend/public/plugins/slick-carousel/slick/slick.js
@@ -28,6 +28,7 @@
 }(function($) {
     'use strict';
     var Slick = window.Slick || {};
+    var DOMPurify = require('dompurify')(window);
 
     Slick = (function() {
 
@@ -1748,7 +1749,7 @@
         if ( $imgsToLoad.length ) {
 
             image = $imgsToLoad.first();
-            imageSource = image.attr('data-lazy');
+            imageSource = DOMPurify.sanitize(image.attr('data-lazy'));
             imageSrcSet = image.attr('data-srcset');
             imageSizes  = image.attr('data-sizes') || _.$slider.attr('data-sizes');
             imageToLoad = document.createElement('img');


### PR DESCRIPTION
Fixes [https://github.com/Priyanshukumaranand/Hacktivespace/security/code-scanning/5](https://github.com/Priyanshukumaranand/Hacktivespace/security/code-scanning/5)

To fix the problem, we need to ensure that the value of the `data-lazy` attribute is properly sanitized or validated before it is used to set the `src` attribute of the `img` element. One way to achieve this is by using a well-known library like DOMPurify to sanitize the URL.

- Import the DOMPurify library.
- Sanitize the `imageSource` value before assigning it to `imageToLoad.src`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
